### PR TITLE
deepep_ll fixes + mistral large fixes

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
 )
+from vllm.platforms import current_platform
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
@@ -295,8 +296,14 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             self.max_tokens_per_rank,
             num_experts,
             use_fp8=self.use_fp8_dispatch,
-            round_scale=self.use_ue8m0_dispatch,
-            use_ue8m0=self.use_ue8m0_dispatch,
+            **(
+                dict(
+                    round_scale=self.use_ue8m0_dispatch,
+                    use_ue8m0=self.use_ue8m0_dispatch,
+                )
+                if not current_platform.is_rocm()
+                else dict()
+            ),
             **(dict(use_nvfp4=True) if use_nvfp4 else dict()),
             **(
                 dict(x_global_scale=qc_a1_gscale_or_scale)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2520,7 +2520,12 @@ class GPUModelRunner(
 
         assert self.eplb_state is not None
         model = self.get_model()
-        assert is_mixture_of_experts(model)
+        maybe_moe_model = (
+            model.language_model
+            if getattr(model, "language_model", None) is not None
+            else model
+        )
+        assert is_mixture_of_experts(maybe_moe_model)
         self.eplb_state.step(
             is_dummy,
             is_profile,
@@ -3920,7 +3925,13 @@ class GPUModelRunner(
             and mm_config.is_multimodal_pruning_enabled()
         )
 
-        if is_mixture_of_experts(self.model) and self.parallel_config.enable_eplb:
+        maybe_moe_model = (
+            self.model.language_model
+            if getattr(self.model, "language_model", None) is not None
+            else self.model
+        )
+        if is_mixture_of_experts(maybe_moe_model) and self.parallel_config.enable_eplb:
+            moe_model = maybe_moe_model
             logger.info_once("EPLB is enabled for model %s.", self.model_config.model)
             global_expert_load = (
                 global_expert_loads[eplb_models] if global_expert_loads else None
@@ -3932,7 +3943,7 @@ class GPUModelRunner(
             )
             assert self.eplb_state is not None
             self.eplb_state.add_model(
-                self.model,
+                moe_model,
                 self.model_config,
                 global_expert_load,
                 old_global_expert_indices,


### PR DESCRIPTION
deepep_ll - ignore unrecognized low_latency_dispatch flags
mistral large - support multi modal model for eplb

For mistral after the eplb fix,

```
vllm serve /mnt/models/mistralai/Mistral-Large-3-675B-Instruct-2512 --data-parallel-size 8 --enable-expert-parallel --all2all-backend deepep_low_latency --port 9010                  --eplb-config '{"window_size":"100",
                                "step_interval":"50",
                                "num_redundant_experts":"32",
                                "log_balancedness":"True"}'                 --compilation_config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' --enable-eplb  --max-model-len 8192 
```

```
lm_eval --model local-completions --model_args model=/mnt/models/mistralai/Mistral-Large-3-675B-Instruct-2512,base_url=http://127.0.0.1:9010/v1/completions,tokenized_requests=False,num_concurrent=100,trust_remote_code=True --tasks gsm8k --limit 100
```

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.81|±  |0.0394|
|     |       |strict-match    |     5|exact_match|↑  | 0.44|±  |0.0499|
```