### PR TITLE
MORI - Traffic Class update

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -11,8 +11,8 @@ ARG FA_BRANCH="0e60e394"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
 ARG AITER_BRANCH="6af8b687"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
-ARG MORI_BRANCH="2d02c6a9"
-ARG MORI_REPO="https://github.com/ROCm/mori.git"
+ARG MORI_BRANCH="varun/tc-setting"
+ARG MORI_REPO="https://github.com/varun-sundar-rabindranath/mori.git"
 
 # Sccache configuration (only used in release pipeline)
 ARG USE_SCCACHE

--- a/tools/ep_kernels/amd_wideep/install_dependencies.sh
+++ b/tools/ep_kernels/amd_wideep/install_dependencies.sh
@@ -91,7 +91,7 @@ function build_rocshmem_v2() {
 function build_deepep_v2() {
     DEEPEP_BRANCH="main"
     DEEPEP_REPO="https://github.com/ROCm/DeepEP"
-    ARG NIC_COMPILATION_ARCH=cx7
+    NIC_COMPILATION_ARCH=cx7
     git clone -b ${DEEPEP_BRANCH} ${DEEPEP_REPO} && \
         cd DeepEP && \
         PYTORCH_ROCM_ARCH=$GFX_COMPILATION_ARCH \


### PR DESCRIPTION
On the OCI machine, MORI all2all communications happen on the backend nics, but with priority 1. We want MORI all2alls to communicate with priority 0. To this effect, this PR updates the docker files to use https://github.com/varun-sundar-rabindranath/mori/tree/varun/tc-setting that does the appropriate traffic class updates. 
