### PR TITLE
Add NVFP4 dispatch support for DeepEP v2

### DIFF
--- a/tests/kernels/moe/parallel_utils.py
+++ b/tests/kernels/moe/parallel_utils.py
@@ -214,6 +214,7 @@ class DeepEPV2Args:
     hidden_size: int
     max_tokens_per_rank: int
     use_fp8_dispatch: bool
+    use_nvfp4_dispatch: bool = False
 
 
 def make_deepep_v2_a2a(
@@ -231,6 +232,8 @@ def make_deepep_v2_a2a(
         hidden=v2_args.hidden_size,
         num_topk=v2_args.num_topk,
         use_fp8_dispatch=v2_args.use_fp8_dispatch,
+        use_nvfp4_dispatch=v2_args.use_nvfp4_dispatch,
+        use_fp8_sf=v2_args.use_nvfp4_dispatch,
         explicitly_destroy=True,
     )
     return DeepEPV2PrepareAndFinalize(
@@ -241,5 +244,6 @@ def make_deepep_v2_a2a(
         num_experts=v2_args.num_experts,
         num_topk=v2_args.num_topk,
         use_fp8_dispatch=v2_args.use_fp8_dispatch,
+        use_nvfp4_dispatch=v2_args.use_nvfp4_dispatch,
         use_cudagraph=use_cudagraph,
     )

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -784,6 +784,7 @@ class DeepEPV2All2AllManager(All2AllManagerBase):
         hidden: int,
         num_topk: int,
         use_fp8_dispatch: bool,
+        use_nvfp4_dispatch: bool = False,
     ) -> dict:
         return dict(
             group=self._device_group if self._device_group is not None
@@ -792,6 +793,8 @@ class DeepEPV2All2AllManager(All2AllManagerBase):
             hidden=hidden,
             num_topk=num_topk,
             use_fp8_dispatch=use_fp8_dispatch,
+            use_nvfp4_dispatch=use_nvfp4_dispatch,
+            use_fp8_sf=use_nvfp4_dispatch,
             allow_hybrid_mode=envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE,
             prefer_overlap_with_compute=envs.VLLM_DEEPEP_V2_PREFER_OVERLAP,
             allow_multiple_reduction=(envs.VLLM_DEEPEP_V2_ALLOW_MULTIPLE_REDUCTION),

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -201,12 +201,17 @@ def maybe_make_prepare_finalize(
             and quant_config.quant_dtype == current_platform.fp8_dtype()
             and quant_config.is_block_quantized
         )
+        use_nvfp4_dispatch = (
+            quant_config is not None
+            and quant_config.quant_dtype == "nvfp4"
+        )
         all_to_all_args = dict(
             num_max_tokens_per_rank=moe.max_num_tokens,
             hidden=moe.hidden_dim,
             num_topk=moe.experts_per_token,
             num_experts=moe.num_experts,
             use_fp8_dispatch=use_fp8_dispatch,
+            use_nvfp4_dispatch=use_nvfp4_dispatch,
         )
         handle = all2all_manager.get_handle(all_to_all_args)
         vllm_config = get_current_vllm_config()
@@ -220,6 +225,7 @@ def maybe_make_prepare_finalize(
             num_experts=moe.num_experts,
             num_topk=moe.experts_per_token,
             use_fp8_dispatch=use_fp8_dispatch,
+            use_nvfp4_dispatch=use_nvfp4_dispatch,
             use_cudagraph=use_cudagraph,
         )
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -73,13 +73,10 @@ def _unpack_fp8_scales(
 @torch.compile(dynamic=True)
 def per_token_cast_to_nvfp4(
     x: torch.Tensor,
-    global_scale: torch.Tensor | None = None,
     use_fp8_sf: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
     m, n = x.shape
-    if global_scale is not None:
-        x = x / global_scale
     aligned_n = round_up(n, 16)
     x_padded = F.pad(x, (0, aligned_n - n), mode='constant', value=0)
     x_padded_view = x_padded.view(m, -1, 16)
@@ -184,8 +181,10 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         if self.use_nvfp4_dispatch and token_scales is None:
+            if a1_scale is not None:
+                tokens = tokens / a1_scale
             tokens, token_scales = per_token_cast_to_nvfp4(
-                tokens, global_scale=a1_scale, use_fp8_sf=True)
+                tokens, use_fp8_sf=True)
 
         has_scales = token_scales is not None
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -155,6 +155,7 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 quant_dtype=quant_config.quant_dtype,
                 per_act_token_quant=False,
                 block_shape=quant_config.block_shape,
+                is_scale_swizzled=False,
             )
             token_scales = _pack_fp8_scales(token_scales)
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -181,8 +181,6 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         if self.use_nvfp4_dispatch and token_scales is None:
-            if a1_scale is not None:
-                tokens = tokens / a1_scale
             tokens, token_scales = per_token_cast_to_nvfp4(
                 tokens, use_fp8_sf=True)
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -63,9 +63,12 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         num_experts: int,
         num_topk: int,
         use_fp8_dispatch: bool = False,
+        use_nvfp4_dispatch: bool = False,
         use_cudagraph: bool = False,
     ):
         super().__init__()
+        assert not (use_fp8_dispatch and use_nvfp4_dispatch), \
+            "Cannot use both FP8 and NVFP4 dispatch simultaneously"
         self.buffer = buffer
         self.num_dispatchers_ = num_dispatchers
         self.dp_size = dp_size
@@ -73,6 +76,7 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.num_experts = num_experts
         self.num_topk = num_topk
         self.use_fp8_dispatch = use_fp8_dispatch
+        self.use_nvfp4_dispatch = use_nvfp4_dispatch
         self.use_cudagraph = use_cudagraph
 
         # DBO microbatching: one handle slot per micro-batch.
@@ -105,6 +109,10 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         quant_config: FusedMoEQuantConfig,
         defer_input_quant: bool,
     ) -> Callable:
+        if self.use_nvfp4_dispatch and token_scales is None:
+            tokens, token_scales = deep_ep.per_token_cast_to_nvfp4(
+                tokens, use_fp8_sf=True)
+
         has_scales = token_scales is not None
 
         token_data = tokens
@@ -214,7 +222,9 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             recv_expert_num_tokens, device=expert_x.device,
         )
 
-        if not quant_config.is_block_quantized and not defer_input_quant:
+        if (not quant_config.is_block_quantized
+                and not defer_input_quant
+                and not self.use_nvfp4_dispatch):
             expert_x_scale = None
             if expert_x.numel() != 0:
                 expert_x, expert_x_scale = moe_kernel_quantize_input(

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -283,7 +283,7 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                     quant_dtype=quant_config.quant_dtype,
                     per_act_token_quant=False,
                     block_shape=quant_config.block_shape,
-                    is_scale_swizzled=quant_config.is_scale_swizzled,
+                    is_scale_swizzled=getattr(quant_config, 'is_scale_swizzled', quant_config.is_nvfp4_scale_swizzled),
                 )
 
         return (

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -110,7 +110,8 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         if self.use_nvfp4_dispatch and token_scales is None:
-            tokens, token_scales = deep_ep.per_token_cast_to_nvfp4(
+            from deep_ep.utils.math import per_token_cast_to_nvfp4
+            tokens, token_scales = per_token_cast_to_nvfp4(
                 tokens, use_fp8_sf=True)
 
         has_scales = token_scales is not None

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -19,39 +19,26 @@ from vllm.v1.worker.ubatching import (
 )
 
 
-# per_token_cast_to_nvfp4 output layout:
-#   data:   uint8  [M, H/2]   — two e2m1 nibbles packed per byte
-#   scales: int32  [M, H/64]  — four fp8_e4m3fn scales packed per int32
-#                                int32 = s0 | (s1<<8) | (s2<<16) | (s3<<24)
-
-
-def _float_to_e2m1_packed(x: torch.Tensor) -> torch.Tensor:
-    assert x.dim() == 2 and x.shape[1] % 2 == 0
-    m, n = x.shape
-    abs_x = x.abs()
-    sign = (x < 0).to(torch.uint8)
-    abs_x_log2 = torch.log2(abs_x.clamp(min=2**-10))
-    exp = torch.floor(abs_x_log2 + 1).clamp(0, 3).to(torch.uint8)
-    mant = ((abs_x_log2 + 1 - exp.float()) > 0.5).to(torch.uint8)
-    nibbles = (sign << 3) | (exp << 1) | mant
-    even = nibbles[:, 0::2]
-    odd = nibbles[:, 1::2]
-    return (even | (odd << 4)).to(torch.uint8)
+# DeepEP v2 nvfp4 dispatch scale packing:
+#   scales: int32 [M, H/64] — four fp8_e4m3fn bytes packed per int32
+#           int32 = s0 | (s1<<8) | (s2<<16) | (s3<<24)
 
 
 def _pack_fp8_scales(scales: torch.Tensor) -> torch.Tensor:
     m, num_scales = scales.shape
+    if scales.dtype != torch.uint8:
+        if scales.dtype != torch.float8_e4m3fn:
+            scales = scales.to(torch.float8_e4m3fn)
+        scales = scales.view(torch.uint8)
     aligned_num = round_up(num_scales, 4)
     if aligned_num > num_scales:
         scales = F.pad(scales, (0, aligned_num - num_scales),
                        mode='constant', value=0)
-    scales_fp8 = scales.to(torch.float8_e4m3fn)
-    scales_u8 = scales_fp8.view(torch.uint8).to(torch.int32)
-    scales_packed = scales_u8.view(m, -1, 4)
-    result = (scales_packed[:, :, 0]
-              | (scales_packed[:, :, 1] << 8)
-              | (scales_packed[:, :, 2] << 16)
-              | (scales_packed[:, :, 3] << 24))
+    scales_i32 = scales.to(torch.int32).view(m, -1, 4)
+    result = (scales_i32[:, :, 0]
+              | (scales_i32[:, :, 1] << 8)
+              | (scales_i32[:, :, 2] << 16)
+              | (scales_i32[:, :, 3] << 24))
     if num_scales < aligned_num:
         return result[:, :num_scales // 4].contiguous()
     return result
@@ -68,25 +55,6 @@ def _unpack_fp8_scales(
     unpacked = torch.stack([b0, b1, b2, b3], dim=-1).view(m, -1)
     unpacked = unpacked[:, :num_scales]
     return unpacked.to(torch.uint8).view(torch.float8_e4m3fn)
-
-
-@torch.compile(dynamic=True)
-def per_token_cast_to_nvfp4(
-    x: torch.Tensor,
-    use_fp8_sf: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    assert x.dim() == 2
-    m, n = x.shape
-    aligned_n = round_up(n, 16)
-    x_padded = F.pad(x, (0, aligned_n - n), mode='constant', value=0)
-    x_padded_view = x_padded.view(m, -1, 16)
-    x_amax = x_padded_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
-    x_scaled = (x_padded_view * (6.0 / x_amax.unsqueeze(2))).float()
-    x_e2m1 = _float_to_e2m1_packed(x_scaled.view(m, aligned_n))[:, :n // 2]
-    scales = (x_amax / 6.0).view(m, -1)
-    if use_fp8_sf:
-        scales = _pack_fp8_scales(scales)
-    return x_e2m1.contiguous(), scales
 
 
 class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
@@ -181,8 +149,15 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         if self.use_nvfp4_dispatch and token_scales is None:
-            tokens, token_scales = per_token_cast_to_nvfp4(
-                tokens, use_fp8_sf=True)
+            tokens, token_scales = moe_kernel_quantize_input(
+                tokens,
+                a1_scale,
+                quant_dtype=quant_config.quant_dtype,
+                per_act_token_quant=False,
+                block_shape=quant_config.block_shape,
+                is_scale_swizzled=quant_config.is_scale_swizzled,
+            )
+            token_scales = _pack_fp8_scales(token_scales)
 
         has_scales = token_scales is not None
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 import deep_ep
 import torch
-import torch.nn.functional as F
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
@@ -17,44 +16,6 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
 )
-
-
-# DeepEP v2 nvfp4 dispatch scale packing:
-#   scales: int32 [M, H/64] — four fp8_e4m3fn bytes packed per int32
-#           int32 = s0 | (s1<<8) | (s2<<16) | (s3<<24)
-
-
-def _pack_fp8_scales(scales: torch.Tensor) -> torch.Tensor:
-    m, num_scales = scales.shape
-    if scales.dtype != torch.uint8:
-        if scales.dtype != torch.float8_e4m3fn:
-            scales = scales.to(torch.float8_e4m3fn)
-        scales = scales.view(torch.uint8)
-    aligned_num = round_up(num_scales, 4)
-    if aligned_num > num_scales:
-        scales = F.pad(scales, (0, aligned_num - num_scales),
-                       mode='constant', value=0)
-    scales_i32 = scales.to(torch.int32).view(m, -1, 4)
-    result = (scales_i32[:, :, 0]
-              | (scales_i32[:, :, 1] << 8)
-              | (scales_i32[:, :, 2] << 16)
-              | (scales_i32[:, :, 3] << 24))
-    if num_scales < aligned_num:
-        return result[:, :num_scales // 4].contiguous()
-    return result
-
-
-def _unpack_fp8_scales(
-    packed: torch.Tensor, num_scales: int,
-) -> torch.Tensor:
-    m = packed.shape[0]
-    b0 = packed & 0xFF
-    b1 = (packed >> 8) & 0xFF
-    b2 = (packed >> 16) & 0xFF
-    b3 = (packed >> 24) & 0xFF
-    unpacked = torch.stack([b0, b1, b2, b3], dim=-1).view(m, -1)
-    unpacked = unpacked[:, :num_scales]
-    return unpacked.to(torch.uint8).view(torch.float8_e4m3fn)
 
 
 class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
@@ -157,7 +118,8 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 block_shape=quant_config.block_shape,
                 is_scale_swizzled=False,
             )
-            token_scales = _pack_fp8_scales(token_scales)
+            # uint8 [M, H/16] → int32 [M, H/64] for DeepEP fp8_sf transport
+            token_scales = token_scales.view(torch.int32)
 
         has_scales = token_scales is not None
 
@@ -269,9 +231,9 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         )
 
         if self.use_nvfp4_dispatch and expert_x_scale is not None:
-            num_scales = expert_x.shape[1] // 8  # H/2 packed → H/16 groups
-            expert_x_scale = _unpack_fp8_scales(
-                expert_x_scale, num_scales)
+            # int32 [M, H/64] → fp8 [M, H/16]
+            expert_x_scale = expert_x_scale.view(torch.uint8).view(
+                torch.float8_e4m3fn)
 
         if (not quant_config.is_block_quantized
                 and not defer_input_quant

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import deep_ep
 import torch
+import torch.nn.functional as F
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
@@ -16,6 +17,79 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
 )
+
+
+# per_token_cast_to_nvfp4 output layout:
+#   data:   uint8  [M, H/2]   — two e2m1 nibbles packed per byte
+#   scales: int32  [M, H/64]  — four fp8_e4m3fn scales packed per int32
+#                                int32 = s0 | (s1<<8) | (s2<<16) | (s3<<24)
+
+
+def _float_to_e2m1_packed(x: torch.Tensor) -> torch.Tensor:
+    assert x.dim() == 2 and x.shape[1] % 2 == 0
+    m, n = x.shape
+    abs_x = x.abs()
+    sign = (x < 0).to(torch.uint8)
+    abs_x_log2 = torch.log2(abs_x.clamp(min=2**-10))
+    exp = torch.floor(abs_x_log2 + 1).clamp(0, 3).to(torch.uint8)
+    mant = ((abs_x_log2 + 1 - exp.float()) > 0.5).to(torch.uint8)
+    nibbles = (sign << 3) | (exp << 1) | mant
+    even = nibbles[:, 0::2]
+    odd = nibbles[:, 1::2]
+    return (even | (odd << 4)).to(torch.uint8)
+
+
+def _pack_fp8_scales(scales: torch.Tensor) -> torch.Tensor:
+    m, num_scales = scales.shape
+    aligned_num = round_up(num_scales, 4)
+    if aligned_num > num_scales:
+        scales = F.pad(scales, (0, aligned_num - num_scales),
+                       mode='constant', value=0)
+    scales_fp8 = scales.to(torch.float8_e4m3fn)
+    scales_u8 = scales_fp8.view(torch.uint8).to(torch.int32)
+    scales_packed = scales_u8.view(m, -1, 4)
+    result = (scales_packed[:, :, 0]
+              | (scales_packed[:, :, 1] << 8)
+              | (scales_packed[:, :, 2] << 16)
+              | (scales_packed[:, :, 3] << 24))
+    if num_scales < aligned_num:
+        return result[:, :num_scales // 4].contiguous()
+    return result
+
+
+def _unpack_fp8_scales(
+    packed: torch.Tensor, num_scales: int,
+) -> torch.Tensor:
+    m = packed.shape[0]
+    b0 = packed & 0xFF
+    b1 = (packed >> 8) & 0xFF
+    b2 = (packed >> 16) & 0xFF
+    b3 = (packed >> 24) & 0xFF
+    unpacked = torch.stack([b0, b1, b2, b3], dim=-1).view(m, -1)
+    unpacked = unpacked[:, :num_scales]
+    return unpacked.to(torch.uint8).view(torch.float8_e4m3fn)
+
+
+@torch.compile(dynamic=True)
+def per_token_cast_to_nvfp4(
+    x: torch.Tensor,
+    global_scale: torch.Tensor | None = None,
+    use_fp8_sf: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    if global_scale is not None:
+        x = x / global_scale
+    aligned_n = round_up(n, 16)
+    x_padded = F.pad(x, (0, aligned_n - n), mode='constant', value=0)
+    x_padded_view = x_padded.view(m, -1, 16)
+    x_amax = x_padded_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
+    x_scaled = (x_padded_view * (6.0 / x_amax.unsqueeze(2))).float()
+    x_e2m1 = _float_to_e2m1_packed(x_scaled.view(m, aligned_n))[:, :n // 2]
+    scales = (x_amax / 6.0).view(m, -1)
+    if use_fp8_sf:
+        scales = _pack_fp8_scales(scales)
+    return x_e2m1.contiguous(), scales
 
 
 class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
@@ -110,9 +184,8 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         if self.use_nvfp4_dispatch and token_scales is None:
-            from deep_ep.utils.math import per_token_cast_to_nvfp4
             tokens, token_scales = per_token_cast_to_nvfp4(
-                tokens, use_fp8_sf=True)
+                tokens, global_scale=a1_scale, use_fp8_sf=True)
 
         has_scales = token_scales is not None
 
@@ -222,6 +295,11 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         expert_tokens_meta = mk.ExpertTokensMetadata.make_from_list(
             recv_expert_num_tokens, device=expert_x.device,
         )
+
+        if self.use_nvfp4_dispatch and expert_x_scale is not None:
+            num_scales = expert_x.shape[1] // 8  # H/2 packed → H/16 groups
+            expert_x_scale = _unpack_fp8_scales(
+                expert_x_scale, num_scales)
 
         if (not quant_config.is_block_quantized
                 and not defer_input_quant

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -155,7 +155,6 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 quant_dtype=quant_config.quant_dtype,
                 per_act_token_quant=False,
                 block_shape=quant_config.block_shape,
-                is_scale_swizzled=quant_config.is_scale_swizzled,
             )
             token_scales = _pack_fp8_scales(token_scales)
 


### PR DESCRIPTION
## Summary
- Automatically enables NVFP4 dispatch when the model uses nvfp4 quantization with DeepEP v2 ElasticBuffer
- Quantizes activations to NVFP4 with fp8 scale factors (`use_fp8_sf=True`) before dispatch for bandwidth reduction
- Skips receiver-side requantization since data arrives kernel-ready for TrtLLM/grouped gemm
- Plumbs `use_nvfp4_dispatch` and `use_fp8_sf` through `all2all.py`, `all2all_utils.py`, `deepep_v2.py`, and test helpers

## Test plan
- [ ] Run `test_deep_ep_v2_moe` with nvfp4 quantized model
- [ ] Verify dispatch produces packed uint8 `[M, H/2]` + int32-packed fp8 scales `[M, H/64]`
- [ ] Verify received data passes directly to TrtLLM kernel without dequant/requant
- [ ] Confirm FP8 and NVFP4 dispatch mutual exclusion assertion fires when both set

Depends on DeepEP commits:
- https://github.com/elvircrn/DeepEP/commit/9db0299 (NVFP4 dispatch support)
- https://github.com/elvircrn/DeepEP/commit/ae42373 (Reduce scale storage / `use_fp8_sf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)