### PR TITLE
Simplify packed KV cache handling

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -842,7 +842,8 @@ class NixlBaseConnectorWorker:
         self.register_kv_caches({first_layer: kv_cache})
 
     def _register_packed_kv_cache(
-        self, kv_cache: torch.Tensor, block_stride: int
+        self,
+        storage: torch.UntypedStorage,
     ) -> None:
         """Register a packed KV cache as a single NIXL region.
 
@@ -867,7 +868,11 @@ class NixlBaseConnectorWorker:
             self.transfer_topo.cross_layers_blocks,
         )
 
-        total_size = kv_cache.numel() * kv_cache.element_size()
+        total_size = storage.nbytes()
+        block_stride = total_size // self.num_blocks
+        base_addr = storage.data_ptr()
+        device_id = storage.device.index
+        assert device_id is not None
 
         logger.info(
             "Registering packed KV cache: total_size=%s, block_stride=%s, "
@@ -877,19 +882,18 @@ class NixlBaseConnectorWorker:
             self.num_blocks,
         )
 
-        self.device_id = max(kv_cache.get_device(), 0)
-        caches_data = [(kv_cache.data_ptr(), total_size, self.device_id, "")]
+        self.device_id = device_id
+        caches_data = [(base_addr, total_size, self.device_id, "")]
 
         self.block_len_per_layer = [block_stride]
         self.num_regions = 1
         self.num_descs = self.num_blocks
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = [kv_cache.data_ptr()]
+        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = [base_addr]
 
         descs = self.nixl_wrapper.get_reg_descs(caches_data, self.nixl_memory_type)
         self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
         self._registered_descs.append(descs)
 
-        self.device_kv_caches = {layer: kv_cache for layer in self._layer_specs}
         self.dst_num_blocks[self.engine_id] = self.num_blocks
 
         self.src_xfer_handles_by_block_size[self.block_size], (self.src_blocks_data) = (
@@ -927,20 +931,14 @@ class NixlBaseConnectorWorker:
         # same backing storage (different data_ptr but same storage).
         # This happens with DSv4-style contiguous per-block packing.
         if len(kv_caches) > 1:
-            storage_ptrs: dict[int, torch.Tensor] = {}
-            data_ptrs: set[int] = set()
-            for cache in kv_caches.values():
-                if isinstance(cache, torch.Tensor):
-                    storage_ptrs[cache.untyped_storage().data_ptr()] = cache
-                    data_ptrs.add(cache.data_ptr())
+            storage = next(iter(kv_caches.values())).untyped_storage()
+            storage_ptrs = {
+                cache.untyped_storage().data_ptr() for cache in kv_caches.values()
+            }
+            data_ptrs = {cache.data_ptr() for cache in kv_caches.values()}
             if len(storage_ptrs) == 1 and len(data_ptrs) > 1:
-                any_cache = next(iter(storage_ptrs.values()))
-                total_bytes = any_cache.untyped_storage().nbytes()
-                block_stride = total_bytes // self.num_blocks
-                flat = torch.tensor(
-                    [], dtype=torch.uint8, device=any_cache.device
-                ).set_(any_cache.untyped_storage())
-                self._register_packed_kv_cache(flat, block_stride)
+                self._register_packed_kv_cache(storage)
+                self.device_kv_caches = kv_caches
                 return
 
         self.transfer_topo = TransferTopology(

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from math import prod
 from typing import Any, cast
 
 import torch
@@ -254,18 +255,16 @@ def _reshape_kv_cache(
                 ]
 
                 dtype = kv_cache_spec.dtype
-                kv_tensor = kv_raw_tensor.view(dtype)
                 if packing is not None:
-                    layer_offset, blk_stride = packing
-                    dtype_size = get_dtype_size(dtype)
-                    page_stride = blk_stride // dtype_size
-                    strides = list(torch.empty(kv_cache_shape).stride())
-                    strides[inv_order[0]] = page_stride
-                    kv_cache = torch.as_strided(
-                        kv_tensor,
-                        size=kv_cache_shape,
-                        stride=tuple(strides),
-                        storage_offset=layer_offset // dtype_size,
+                    offset, block_stride = packing
+                    assert inv_order[0] == 0
+                    page_bytes = prod(kv_cache_shape[1:]) * get_dtype_size(dtype)
+                    kv_cache = (
+                        kv_raw_tensor.view(-1, block_stride)[
+                            :, offset : offset + page_bytes
+                        ]
+                        .view(dtype)
+                        .view(kv_cache_shape)
                     )
                 elif kv_cache_spec.page_size_padded is not None:
                     # Use strided view to handle page_size_bytes that
@@ -280,13 +279,13 @@ def _reshape_kv_cache(
                     strides = list(torch.empty(kv_cache_shape).stride())
                     strides[inv_order[0]] = page_stride
                     kv_cache = torch.as_strided(
-                        kv_tensor,
+                        kv_raw_tensor.view(dtype),
                         size=kv_cache_shape,
                         stride=tuple(strides),
                     )
                 else:
                     # No padding — safe to use a contiguous view.
-                    kv_cache = kv_tensor.view(kv_cache_shape)
+                    kv_cache = kv_raw_tensor.view(dtype).view(kv_cache_shape)
                 kv_caches[layer_name] = kv_cache.permute(*inv_order)
 
             elif isinstance(kv_cache_spec, MambaSpec):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
 from functools import reduce
+from math import prod
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, cast
 
 import numpy as np
@@ -7151,18 +7152,15 @@ class GPUModelRunner(
                         for i in range(len(kv_cache_stride_order))
                     ]
 
-                    raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
                     if packing is not None:
-                        layer_offset, blk_stride = packing
-                        dtype_size = get_dtype_size(dtype)
-                        page_stride = blk_stride // dtype_size
-                        strides = list(torch.empty(kv_cache_shape).stride())
-                        strides[inv_order[0]] = page_stride
-                        kv_cache = torch.as_strided(
-                            raw_tensor,
-                            size=kv_cache_shape,
-                            stride=tuple(strides),
-                            storage_offset=layer_offset // dtype_size,
+                        offset, block_stride = packing
+                        assert inv_order[0] == 0
+                        page_bytes = prod(kv_cache_shape[1:]) * get_dtype_size(dtype)
+                        kv_cache = (
+                            kv_cache_raw_tensors[layer_name]
+                            .view(-1, block_stride)[:, offset : offset + page_bytes]
+                            .view(dtype)
+                            .view(kv_cache_shape)
                         )
                     elif kv_cache_spec.page_size_padded is not None:
                         # Use strided view to handle page_size_bytes that
@@ -7178,13 +7176,17 @@ class GPUModelRunner(
                         strides = list(torch.empty(kv_cache_shape).stride())
                         strides[inv_order[0]] = page_stride
                         kv_cache = torch.as_strided(
-                            raw_tensor,
+                            kv_cache_raw_tensors[layer_name].view(dtype),
                             size=kv_cache_shape,
                             stride=tuple(strides),
                         )
                     else:
                         # No padding — safe to use a contiguous view.
-                        kv_cache = raw_tensor.view(kv_cache_shape)
+                        kv_cache = (
+                            kv_cache_raw_tensors[layer_name]
+                            .view(dtype)
+                            .view(kv_cache_shape)
+                        )
                     kv_caches[layer_name] = kv_cache.permute(*inv_order)
 
                 elif isinstance(kv_cache_spec, MambaSpec):


### PR DESCRIPTION
## Summary
- Replace the packed-layer `as_strided` path in both GPU runner reshape paths with a byte-view/slice plus dtype view of the packed backing.
- Leave the existing padded-page `as_strided` branches intact.
- Simplify NIXL packed-backing detection to use direct shared-storage/data-pointer set checks over the typed KV cache tensors.

## Duplicate work check
- This is stacked against `tlrmchlsmth:cross_layer_dsv4` / vllm-project/vllm#44577, so it is not a competing upstream PR.
- Checked open vLLM PRs for `DeepSeek V4 packed KV`, `NIXL packed KV cache`, and `44577 in:body`; #44577 is the target branch, while the other hits are separate DSv4/ROCm/kernel/NIXL work.

## Tests
- `.venv/bin/pre-commit run --files vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py` - passed.
- Commit hook/pre-commit on staged files - passed.
- `.venv/bin/python -m pytest tests/v1/core/test_contiguous_kv_packing.py -q` - failed 2/5 in a test file that is not in this PR diff: `MagicMock` size comparison and mocked storage-size mismatch in `test_strided_views_are_independent`.
- `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py -q` - failed locally due environment/setup issues: Hugging Face cache permission under `/data/engine/hub_cache`, UCX/NIXL backend init blocked by low locked-memory limit (`ulimit -l` 8192) / `NIXL_ERR_BACKEND`; result before teardown was 55 passed, 2 skipped, 12 failed, then a teardown segfault.

AI assistance was used for this cleanup; Lucas reviewed and owns the change.